### PR TITLE
Add sidebar layout to HTML docs

### DIFF
--- a/docs/html/assets/style.css
+++ b/docs/html/assets/style.css
@@ -19,12 +19,17 @@
    color: var(--text);
    background: var(--bg);
    line-height: 1.6;
+   min-height: 100vh;
+   display: grid;
+   grid-template-columns: 240px 1fr;
+   grid-template-rows: auto 1fr;
  }
  
  header {
    background: linear-gradient(120deg, #0f172a, #111827 60%, #0b1220);
    border-bottom: 1px solid var(--border);
    padding: 32px 20px 16px;
+   grid-column: 1 / -1;
  }
  
  header h1 {
@@ -39,27 +44,34 @@
  
  nav {
    background: var(--panel);
-   border-bottom: 1px solid var(--border);
-   padding: 12px 20px;
+   border-right: 1px solid var(--border);
+   padding: 20px;
    display: flex;
-   flex-wrap: wrap;
-   gap: 12px 16px;
+   flex-direction: column;
+   gap: 8px;
+   grid-row: 2;
+   grid-column: 1;
  }
  
  nav a {
    color: var(--link);
    text-decoration: none;
    font-weight: 600;
+   padding: 6px 8px;
+   border-radius: 6px;
  }
  
  nav a:hover {
-   text-decoration: underline;
+   background: rgba(125, 211, 252, 0.12);
  }
  
  main {
    padding: 24px 20px 48px;
    max-width: 1100px;
    margin: 0 auto;
+   grid-row: 2;
+   grid-column: 2;
+   width: 100%;
  }
  
  section {
@@ -130,4 +142,26 @@
    text-align: center;
    padding: 24px 16px;
    color: var(--muted);
+ }
+
+ @media (max-width: 900px) {
+   body {
+     grid-template-columns: 1fr;
+     grid-template-rows: auto auto 1fr;
+   }
+
+   nav {
+     grid-row: 2;
+     grid-column: 1;
+     flex-direction: row;
+     flex-wrap: wrap;
+     border-right: none;
+     border-bottom: 1px solid var(--border);
+     gap: 8px 12px;
+   }
+
+   main {
+     grid-row: 3;
+     grid-column: 1;
+   }
  }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: CSS-only layout and styling changes for static docs; main risk is minor visual/layout regressions at different viewport sizes.
> 
> **Overview**
> Updates the HTML docs styling to use a two-column CSS grid with a left sidebar navigation and main content area, with the header spanning full width.
> 
> Refines `nav` link styling (padding/hover background) and adds a `@media (max-width: 900px)` breakpoint to collapse the layout to a single-column, top nav for smaller screens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7777cf12cb6d2fc60128724af4ac1123e5d202b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->