### PR TITLE
Fix Sequential crash when GPU backend is None + update train_mlp example

### DIFF
--- a/examples/train_mlp.py
+++ b/examples/train_mlp.py
@@ -13,16 +13,16 @@ model = nn.Sequential(
     nn.Linear(64, 10),
 )
 
-optimizer = optim.AdamW(model.parameters(), lr=1e-5)
+optimizer = optim.AdamW(model.parameters(), lr=1e-3)
 loss_fn = nn.CrossEntropyLoss()
 
-# Synthetic dataset: 256 samples, 10 classes
+# Synthetic dataset: 512 samples, 10 classes
 np.random.seed(42)
-X = np.random.randn(25600, 64).astype(np.float32)
-y = np.random.randint(0, 10, size=25600)
+X = np.random.randn(512, 64).astype(np.float32)
+y = np.random.randint(0, 10, size=512)
 
 batch_size = 32
-epochs = 100
+epochs = 10
 
 for epoch in range(epochs):
     epoch_loss = 0.0

--- a/nn/containers.py
+++ b/nn/containers.py
@@ -85,7 +85,7 @@ class Sequential(Module):
                 weight = _get_param_array(linear_mod.weight)
                 bias = _get_param_array(linear_mod.bias) if linear_mod.bias is not None else None
                 backend = linear_mod._get_backend()
-                fused_fn = getattr(backend.fnn, method_name, None)
+                fused_fn = getattr(backend.fnn, method_name, None) if backend is not None else None
                 if fused_fn is not None:
                     try:
                         current = fused_fn(


### PR DESCRIPTION
- containers.py: guard `backend.fnn` access with None check — fixes AttributeError on GPUs where `_get_backend()` returns None (e.g. RADV VEGA20)
- train_mlp.py: reduce dataset from 25600×100 to 512×10 for a fast demo, bump lr from 1e-5 to 1e-3 so loss visibly drops in 10 epochs

Closes #38